### PR TITLE
ESTS-136762 Added new fields for a node that gets from RackHD

### DIFF
--- a/discovered-nodes-capabilities-parent/discovered-nodes-capabilities-api/src/main/resources/discovered-nodes-capabilities/schema/json/DiscoveredNode.jsd
+++ b/discovered-nodes-capabilities-parent/discovered-nodes-capabilities-api/src/main/resources/discovered-nodes-capabilities/schema/json/DiscoveredNode.jsd
@@ -5,6 +5,15 @@
     "convergedUuid": {
       "type": "string"
     },
+    "serial": {
+      "type": "string"
+    },
+    "product": {
+      "type": "string"
+    },
+    "vendor": {
+      "type": "string"
+    },
     "allocationStatus": {
       "enum": [
          "DISCOVERED",

--- a/discovered-nodes-capabilities-parent/discovered-nodes-capabilities-api/src/main/resources/discovered-nodes-capabilities/schema/json/includes/NodeEventDataDiscovered.jsd
+++ b/discovered-nodes-capabilities-parent/discovered-nodes-capabilities-api/src/main/resources/discovered-nodes-capabilities/schema/json/includes/NodeEventDataDiscovered.jsd
@@ -14,7 +14,16 @@
     },
     "nodeType": {
       "type": "string"
-    }
+    },
+    "serial": {
+       "type": "string"
+    },
+    "product": {
+       "type": "string"
+    },
+     "vendor": {
+       "type": "string"
+     }
   },
   "type": "object",
   "extends" : {


### PR DESCRIPTION
This PR will ads service-tag, model, vendor fields that gets form RackHd when a node is discovered.

- [ ] I have read the [CONTRIBUTION GUIDE][contributing]
- [ ] This is a bug
- [X ] This is a feature request
- [ ] This is a syntax/style fix
- [ ] This is an improvement to code quality
