### PR TITLE
RHEL 7.2 Installation with MTU Network configruation

### DIFF
--- a/discovered-nodes-capabilities-parent/discovered-nodes-capabilities-api/src/main/resources/discovered-nodes-capabilities/schema/json/includes/BondVlanInterface.jsd
+++ b/discovered-nodes-capabilities-parent/discovered-nodes-capabilities-api/src/main/resources/discovered-nodes-capabilities/schema/json/includes/BondVlanInterface.jsd
@@ -1,25 +1,19 @@
 {
    "$schema":"http://json-schema.org/draft-04/schema#",
-   "javaName":"BondedNetworkDevice",
+   "javaName":"BootImageNetworkDevice",
    "properties":{
-      "device":{
-         "type":"string"
+      "vlanid":{
+         "type":"integer"
       },
       "ipv4":{
          "$ref":"BootImageNetworkAddressV4.jsd"
       },
       "ipv6":{
          "$ref":"BootImageNetworkAddressV6.jsd"
-      },
-      "nics":{
-         "type":"array"
-      },
-      "bondvlaninterface":{
-          "$ref":"BondVlanInterface.jsd"
       }
    },
    "required":[
-      "device"
+      "vlanid"
    ],
    "type":"object"
 }

--- a/discovered-nodes-capabilities-parent/discovered-nodes-capabilities-api/src/main/resources/discovered-nodes-capabilities/schema/json/includes/BootImageNetworkAddressV4.jsd
+++ b/discovered-nodes-capabilities-parent/discovered-nodes-capabilities-api/src/main/resources/discovered-nodes-capabilities/schema/json/includes/BootImageNetworkAddressV4.jsd
@@ -15,14 +15,15 @@
          "items":{
             "javaType":"java.math.BigDecimal"
          },
-         "type":"array"
+         "type":"array",
+         "default":null
       },
       "mtu":{
-        "type":"integer"
+        "type":"integer",
+        "default":null
       }
    },
    "required":[
-
    ],
    "type":"object"
 }


### PR DESCRIPTION
When MTU values are passed for network device configuration, empty VLAN Id list was passed to RackHD template. There is no default value for VLANID. In case MTU is passed and VLAN ID is mising then template request has empty VLAN ID.

<!--
Complete these steps before submitting a pull request:
This section will not appear in the preview.

1. Fork the repository and create a new branch based on master
2. Ensure that your code has adequate test coverage for all new functionality
3. Make sure the test suite passes
4. Label the pull request where appropriate: bug, duplicate, enhancement, etc.
5. Submit your request with a short title and a clear explanation of the changes.

Please mark an [X] and fill in all items that relate to your issue:

-->

- [ ] I have read the [CONTRIBUTION GUIDE][contributing]
- [ ] This is a bug
- [ ] This is a feature request
- [ ] This is a syntax/style fix
- [ ] This is an improvement to code quality

---

Provide a clear description of changes:

[contributing]: http://dellemc-symphony.readthedocs.io/en/latest/contributingtosymphony.html